### PR TITLE
Python 3.10 support

### DIFF
--- a/stagger/frames.py
+++ b/stagger/frames.py
@@ -114,7 +114,7 @@ class Frame(metaclass=abc.ABCMeta):
         "Returns true if this frame is in any of the specified versions of ID3."
         for version in versions:
             if (self._version == version
-                or (isinstance(self._version, collections.Container) 
+                or (isinstance(self._version, collections.abc.Container) 
                     and version in self._version)):
                 return True
         return False
@@ -244,7 +244,7 @@ class TextFrame(Frame):
                 return
             if isinstance(values, str):
                 yield values
-            elif isinstance(values, collections.Iterable):
+            elif isinstance(values, collections.abc.Iterable):
                 for val in values:
                     for v in extract_strs(val):
                         yield v

--- a/stagger/tags.py
+++ b/stagger/tags.py
@@ -359,7 +359,7 @@ class Tag(collections.MutableMapping, metaclass=abc.ABCMeta):
     disc_total = abstractproperty(fget=lambda self: None, fset=lambda self, value: None)
     composer = abstractproperty(fget=lambda self: None, fset=lambda self, value: None)
     genre = abstractproperty(fget=lambda self: None, fset=lambda self, value: None)
-    comment = abstractproperty(fget=lambda self: Non, fset=lambda self, value: None)
+    comment = abstractproperty(fget=lambda self: None, fset=lambda self, value: None)
     grouping = abstractproperty(fget=lambda self: None, fset=lambda self, value: None)
     picture = abstractproperty(fget=lambda self: None, fset=lambda self, value: None)
     sort_title = abstractproperty(fget=lambda self: None, fset=lambda self, value: None)

--- a/stagger/tags.py
+++ b/stagger/tags.py
@@ -219,7 +219,7 @@ class FrameOrder:
         return "<FrameOrder: {0}>".format(", ".join(pair[0] for pair in order))
         
 
-class Tag(collections.MutableMapping, metaclass=abc.ABCMeta):
+class Tag(collections.abc.MutableMapping, metaclass=abc.ABCMeta):
     known_frames = { }        # Maps known frameids to Frame class objects
 
     frame_order = None        # Initialized by stagger.id3
@@ -316,7 +316,7 @@ class Tag(collections.MutableMapping, metaclass=abc.ABCMeta):
             self._frames[key] = [value]
             return
         if self.known_frames[key]._allow_duplicates:
-            if not isinstance(value, collections.Iterable) or isinstance(value, str):
+            if not isinstance(value, collections.abc.Iterable) or isinstance(value, str):
                 raise ValueError("{0} requires a list of frame values".format(key))
             self._frames[key] = [val if isinstance(val, self.known_frames[key])
                                  else self.known_frames[key](val) 


### PR DESCRIPTION
Python 3.10 made breaking changes to the `collections` module that cause stagger to not work.
More info: https://stackoverflow.com/questions/70943244/attributeerror-module-collections-has-no-attribute-mutablemapping/71902541#71902541

I got it working for my own needs. I don't thoroughly understand the issue, and I don't understand stagger well enough to verify that my fix works 100%. However, since it doesn't seem like stagger is being actively maintained, I figured I'd offer it anyway.